### PR TITLE
✨ feat: add results page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { KanaQuiz } from "@/components/kana-quiz";
 import KanaSelect from "@/components/kana-select";
+import { Results } from "@/components/results";
 import { Button } from "@/components/ui/button";
 import {
   combinationHiraganaCategories,
@@ -9,19 +10,17 @@ import {
   mainHiraganaCategories,
 } from "@/lib/kana";
 import { useKanaStore } from "@/lib/state";
-import { useState } from "react";
 
 export default function Home() {
-  const [quiz, setQuiz] = useState(false);
+  const stage = useKanaStore((state) => state.stage);
+  const nextStage = useKanaStore((state) => state.nextStage);
   const selectedKana = useKanaStore((state) => state.kana);
 
   return (
     <main className="flex min-h-screen flex-col items-center p-24">
       <h1 className="text-4xl font-bold tracking-widest">Kana Quiz</h1>
 
-      {quiz ? (
-        <KanaQuiz />
-      ) : (
+      {stage === "select" && (
         <>
           <div className="grid grid-cols-3 gap-8">
             <KanaSelect
@@ -41,12 +40,16 @@ export default function Home() {
           <Button
             variant="secondary"
             disabled={selectedKana.length === 0}
-            onClick={() => setQuiz(true)}
+            onClick={nextStage}
           >
             Start Quiz
           </Button>
         </>
       )}
+
+      {stage === "quiz" && <KanaQuiz />}
+
+      {stage === "results" && <Results />}
     </main>
   );
 }

--- a/components/kana-card.tsx
+++ b/components/kana-card.tsx
@@ -1,17 +1,21 @@
 "use client";
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Hiragana } from "@/lib/kana";
-import { Input } from "./ui/input";
-import { FocusEvent, useRef, useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Hiragana, Romaji } from "@/lib/kana";
+import { useKanaStore } from "@/lib/state";
 import { cn } from "@/lib/utils";
+import { FocusEvent, useRef, useState } from "react";
 
-export function KanaCard({ kana, answer }: { kana: Hiragana; answer: string }) {
+export function KanaCard({ kana, answer }: { kana: Hiragana; answer: Romaji }) {
   const [value, setValue] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
+  const addAnswer = useKanaStore((state) => state.addAnswer);
 
   const handleBlur = (e: FocusEvent<HTMLInputElement>) => {
-    setValue(e.currentTarget.value);
+    const value = e.currentTarget.value;
+    setValue(value);
+    addAnswer(answer, value === answer);
     const nextInput = inputRef.current?.nextElementSibling as HTMLElement;
     if (nextInput) {
       nextInput.scrollIntoView({ behavior: "smooth" });

--- a/components/kana-quiz.tsx
+++ b/components/kana-quiz.tsx
@@ -1,12 +1,13 @@
 "use client";
 
+import { KanaCard } from "@/components/kana-card";
 import { Button } from "@/components/ui/button";
-import { Hiragana, hiraganaQuestions } from "@/lib/kana";
+import { hiraganaQuestions, type Hiragana, type Romaji } from "@/lib/kana";
 import { useKanaStore } from "@/lib/state";
 import { shuffle } from "@/lib/utils";
-import { KanaCard } from "./kana-card";
 
 export function KanaQuiz() {
+  const nextStage = useKanaStore((state) => state.nextStage);
   const selectedKana = useKanaStore((state) => state.kana);
 
   const kanaQuestions = selectedKana.reduce(
@@ -16,7 +17,7 @@ export function KanaQuiz() {
 
   const questions = Object.entries(kanaQuestions).map(([answer, kana]) => ({
     kana: kana as Hiragana,
-    answer,
+    answer: answer as Romaji,
   }));
 
   const shuffledQuestions = shuffle(questions);
@@ -29,7 +30,9 @@ export function KanaQuiz() {
         ))}
       </div>
 
-      <Button variant="default">Submit</Button>
+      <Button variant="default" onClick={nextStage}>
+        Submit
+      </Button>
     </>
   );
 }

--- a/components/results.tsx
+++ b/components/results.tsx
@@ -1,0 +1,39 @@
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Romaji, hiraganaQuestions } from "@/lib/kana";
+import { useKanaStore } from "@/lib/state";
+
+export function Results() {
+  const selectedKana = useKanaStore((state) => state.kana);
+  const answers = useKanaStore((state) => state.answers);
+  const reset = useKanaStore((state) => state.reset);
+  const retry = useKanaStore((state) => state.retry);
+
+  return (
+    <div className="py-8">
+      <h1 className="text-xl">Results</h1>
+      <div className="grid grid-cols-2 gap-4">
+        {selectedKana.map((kanaCategory) => (
+          <Card key={kanaCategory} className="bg-primary">
+            <CardContent>
+              <div className="grid grid-cols-5 gap-4 p-2 pt-6">
+                {Object.entries(hiraganaQuestions[kanaCategory]).map(
+                  ([key, kana]) => (
+                    <div key={kana} className="grid">
+                      <span>{kana}</span>
+                      <span>{answers[key as Romaji] ? "✅" : "❌"}</span>
+                    </div>
+                  ),
+                )}
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+      <div className="mt-8 flex gap-4">
+        <Button onClick={reset}>Reset</Button>
+        <Button onClick={retry}>Retry</Button>
+      </div>
+    </div>
+  );
+}

--- a/lib/kana.ts
+++ b/lib/kana.ts
@@ -228,6 +228,7 @@ export const hiragana = {
 export type HiraganaCategories = typeof hiraganaCategories;
 export type HiraganaCategory = keyof HiraganaCategories;
 export type Hiragana = (typeof hiragana)[keyof typeof hiragana];
+export type Romaji = keyof typeof hiragana;
 
 export const hiraganaQuestions = {
   a: hiraganaA,

--- a/lib/state.ts
+++ b/lib/state.ts
@@ -1,14 +1,24 @@
-import { type HiraganaCategory } from "@/lib/kana";
+import { type HiraganaCategory, type Romaji } from "@/lib/kana";
 import { create } from "zustand";
 
 type KanaState = {
+  stage: "select" | "quiz" | "results";
   kana: HiraganaCategory[];
+  answers: { [key in Romaji]: boolean };
+  nextStage: () => void;
   toggleKana: (kana: HiraganaCategory) => void;
   toggleAllKana: (kana: HiraganaCategory[]) => void;
+  addAnswer: (romaji: Romaji, correct: boolean) => void;
+  reset: () => void;
+  retry: () => void;
 };
 
 export const useKanaStore = create<KanaState>()((set) => ({
+  stage: "select",
   kana: [] as HiraganaCategory[],
+  answers: {} as { [key in Romaji]: boolean },
+  nextStage: () =>
+    set((state) => ({ stage: state.stage === "select" ? "quiz" : "results" })),
   toggleKana: (kana) =>
     set((state) => ({
       kana: state.kana.includes(kana)
@@ -21,4 +31,19 @@ export const useKanaStore = create<KanaState>()((set) => ({
         ? state.kana.filter((k) => !kana.includes(k))
         : [...new Set([...state.kana, ...kana])],
     })),
+  addAnswer: (romaji, correct) =>
+    set((state) => ({
+      answers: {
+        ...state.answers,
+        [romaji]: state.answers[romaji] ?? correct,
+      },
+    })),
+  reset: () =>
+    set({
+      stage: "select",
+      kana: [],
+      answers: {} as { [key in Romaji]: boolean },
+    }),
+  retry: () =>
+    set({ stage: "quiz", answers: {} as { [key in Romaji]: boolean } }),
 }));


### PR DESCRIPTION
Adds the results page and move more responsibility to the zustand store

## Changes

Moves the current `stage` into `useKanaStore` and provides relevant actions for moving around
```
type KanaState = {
  stage: "select" | "quiz" | "results";
  nextStage: () => void;
  reset: () => void;
  retry: () => void;
  ...
};
```

this then allows the rendering logic to all sit in the same place which is much more manageable
```
return (
      {stage === "select" && <Select />}

      {stage === "quiz" && <KanaQuiz />}

      {stage === "results" && <Results />}
)
```

--- 

Keeps state of your initial answer (if you try and change it we know if you got it wrong the first time), the answers are then shown in the results page